### PR TITLE
fix: do not use the same vars as projects to avoid loose it

### DIFF
--- a/taskfile/docker.yml
+++ b/taskfile/docker.yml
@@ -3,13 +3,13 @@ version: '3'
 internal: true
 
 vars:
-  REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
+  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
 
 
 includes:
   common:
     # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
-    taskfile: '{{.REMOTE_URL}}/common.yml'
+    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
     internal: true
 
 tasks:

--- a/taskfile/go.yml
+++ b/taskfile/go.yml
@@ -3,13 +3,13 @@ version: '3'
 internal: true
 
 vars:
-  REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
+  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
 
 
 includes:
   common:
     # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
-    taskfile: '{{.REMOTE_URL}}/common.yml'
+    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
     internal: true
 tasks:
   build:

--- a/taskfile/js-lib.yml
+++ b/taskfile/js-lib.yml
@@ -4,13 +4,13 @@ internal: true
 
 
 vars:
-  REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
+  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
 
 
 includes:
   common:
     # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
-    taskfile: '{{.REMOTE_URL}}/common.yml'
+    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
     internal: true
     vars:
       EXTENSION: js

--- a/taskfile/rust.yml
+++ b/taskfile/rust.yml
@@ -4,13 +4,13 @@ internal: true
 
 vars:
   RUST_WORKSPACE_DIR: "{{.ROOT_DIR}}/code/rust"
-  REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
+  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
 
 
 includes:
   # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
   common:
-    taskfile: '{{.REMOTE_URL}}/common.yml'
+    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
     internal: true
 
 tasks:


### PR DESCRIPTION
projects uses REMOTE_URL, if we use the same vars it'll be overriden 