### PR TITLE
feat(common): use prompt for the next_upgrade instead of sh script

### DIFF
--- a/taskfile/common.yml
+++ b/taskfile/common.yml
@@ -29,10 +29,11 @@ tasks:
 
   next_upgrade:
     cmds:
-      - ./scripts/next_upgrade.sh
+      - cat ./next_upgrade.md
 
   tag:
     silent: true
+    prompt: 'Did you read the next_upgrade ?'
     deps: [next_upgrade]
     requires:
       vars: [STAGE]

--- a/taskfile/common.yml
+++ b/taskfile/common.yml
@@ -25,16 +25,22 @@ tasks:
     cmds:
       - mkdir -p {{.ROOT_DIR}}/bin
 
-
-
   next_upgrade:
     cmds:
       - cat ./next_upgrade.md
 
   tag:
+    requires:
+      vars: [ STAGE ]
+    cmds:
+      - task: next_upgrade
+      - task: _tag
+        vars: { STAGE: "{{.STAGE}}" }
+
+
+  _tag:
     silent: true
     prompt: 'Did you read the next_upgrade ?'
-    deps: [next_upgrade]
     requires:
       vars: [STAGE]
     vars:


### PR DESCRIPTION
proposition: use the [prompt feature](https://taskfile.dev/usage/#warning-prompts) instead of using our homemade shell script