### PR TITLE
feat(docker): add artifact mock task

### DIFF
--- a/taskfile/docker.yml
+++ b/taskfile/docker.yml
@@ -35,6 +35,6 @@ tasks:
     requires:
       vars: [BINARY_NAME, GIT_REVISION, PATH]
     cmds:
-      - unzip {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.zip
+      - test -f {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.zip && unzip {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.zip
       - docker build -t 563565546264.dkr.ecr.eu-west-1.amazonaws.com/{{.BINARY_NAME}}:{{.GIT_REVISION}} -f {{.PATH}} .
-      - rm ./bootstrap
+      - rm -f ./bootstrap


### PR DESCRIPTION
Missing for https://github.com/pbstck/es-tooling/actions/runs/8434074165/job/23441076339#step:6:33

~~Don't know if it's the correct way to do that, or if the unzip should be done separately, but here's a PR to add a task so we can mock the zip if needed~~

Edit: thanks @ridwan-b for pointing out that the file cannot be unzipped as it's not a real zip

We changed the way to do it, we are testing that the file exists before unzipping
If file is missing and needed, then the build will fail.