### PR TITLE
fix: use default to override vars

### DIFF
--- a/taskfile/rust.yml
+++ b/taskfile/rust.yml
@@ -3,7 +3,8 @@ version: '3'
 internal: true
 
 vars:
-  RUST_WORKSPACE_DIR: "{{.ROOT_DIR}}/code/rust"
+  DEFAULT_RUST_WORKSPACE_DIR: '{{.ROOT_DIR}}/code/rust'
+  RUST_WORKSPACE_DIR: '{{.RUST_WORKSPACE_DIR | default .DEFAULT_RUST_WORKSPACE_DIR}}'
   INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
   TEST_OUTPUT_DIR: '{{default "." .TEST_OUTPUT_DIR}}'
 


### PR DESCRIPTION
fix : https://pubstack.slack.com/archives/CHUC23F16/p1712653152107329
due to : https://github.com/go-task/task/pull/1533
