### PR TITLE
chore: use pipe in default looks more readeable

### DIFF
--- a/taskfile/common.yml
+++ b/taskfile/common.yml
@@ -3,9 +3,9 @@ version: '3'
 internal: true
 
 vars:
-  EXTENSION: '{{default "zip" .EXTENSION}}'
-  FOLDER: '{{default "bin" .FOLDER}}'
-  SUFFIX: '{{default .GIT_REVISION .SUFFIX}}'
+  EXTENSION: '{{.EXTENSION | default "zip"}}'
+  FOLDER: '{{.FOLDER | default "bin"}}'
+  SUFFIX: '{{.SUFFIX | default .GIT_REVISION}}'
 
 tasks:
   artifact/deliver:
@@ -37,7 +37,7 @@ tasks:
     requires:
       vars: [ STAGE ]
     vars:
-      LIB: '{{default false .LIB}}' # Set to true if you want to tag a library (tag format will be v1.yyyymmdd.hhmm)
+      LIB: '{{.LIB | default false}}' # Set to true if you want to tag a library (tag format will be v1.yyyymmdd.hhmm)
       TAG:
         sh: '{{if eq .LIB "false"}} TZ=ETC/UTC date +%Y-%m-%dT%H-%M-%SZ-{{.STAGE}} {{else}} echo "v1".`TZ=ETC/UTC date +%Y%m%d`.`TZ=ETC/UTC date +%-H%M` {{end}}'
     cmds:

--- a/taskfile/infra.yml
+++ b/taskfile/infra.yml
@@ -2,7 +2,7 @@ version: '3'
 
 vars:
   DEFAULT_PLAN_PATH: /tmp/{{.PROJECT}}_plan.plan
-  PLAN_PATH: '{{default .DEFAULT_PLAN_PATH .PLAN_PATH}}'
+  PLAN_PATH: '{{.PLAN_PATH | default .DEFAULT_PLAN_PATH}}'
 tasks:
   terraform/plan:
     requires:

--- a/taskfile/rust.yml
+++ b/taskfile/rust.yml
@@ -5,7 +5,7 @@ internal: true
 vars:
   RUST_WORKSPACE_DIR: "{{.ROOT_DIR}}/code/rust"
   INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
-  TEST_OUTPUT_DIR: '{{default "." .TEST_OUTPUT_DIR}}'
+  TEST_OUTPUT_DIR: '{{.TEST_OUTPUT_DIR } | default "." }}'
 
 includes:
   # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347


### PR DESCRIPTION
Using the pipe operator is more readable (and it's like this in the doc)
