### PR TITLE
chore: remove unecessary vars in include since 3.36

### DIFF
--- a/taskfile/docker.yml
+++ b/taskfile/docker.yml
@@ -2,14 +2,9 @@ version: '3'
 
 internal: true
 
-vars:
-  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
-
-
 includes:
   common:
-    # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
-    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
+    taskfile: common.yml
     internal: true
 
 tasks:

--- a/taskfile/go.yml
+++ b/taskfile/go.yml
@@ -2,14 +2,9 @@ version: '3'
 
 internal: true
 
-vars:
-  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
-
-
 includes:
   common:
-    # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
-    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
+    taskfile: common.yml
     internal: true
 tasks:
   build:

--- a/taskfile/js-lib.yml
+++ b/taskfile/js-lib.yml
@@ -2,15 +2,9 @@ version: '3'
 
 internal: true
 
-
-vars:
-  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
-
-
 includes:
   common:
-    # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
-    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
+    taskfile: common.yml
     internal: true
     vars:
       EXTENSION: js

--- a/taskfile/js-project.yml
+++ b/taskfile/js-project.yml
@@ -2,15 +2,9 @@ version: '3'
 
 internal: true
 
-
-vars:
-  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
-
-
 includes:
   common:
-    # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
-    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
+    taskfile: common.yml
     internal: true
 
 tasks:

--- a/taskfile/rust.yml
+++ b/taskfile/rust.yml
@@ -5,13 +5,12 @@ internal: true
 vars:
   DEFAULT_RUST_WORKSPACE_DIR: '{{.ROOT_DIR}}/code/rust'
   RUST_WORKSPACE_DIR: '{{.RUST_WORKSPACE_DIR | default .DEFAULT_RUST_WORKSPACE_DIR}}'
-  INCLUDED_REMOTE_URL: https://raw.githubusercontent.com/pbstck/taskfiles/v1/taskfile
   TEST_OUTPUT_DIR: '{{.TEST_OUTPUT_DIR | default "." }}'
 
+
 includes:
-  # we can switch to local files when this is releases: https://github.com/go-task/task/pull/1347
   common:
-    taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
+    taskfile: common.yml
     internal: true
 
 tasks:


### PR DESCRIPTION
The fix allows to remote include working properly has been released in the 3.36
