### PR TITLE
feat(js-lib): adapt binaries to support multiple extension

### DIFF
--- a/taskfile/js-lib.yml
+++ b/taskfile/js-lib.yml
@@ -13,7 +13,6 @@ includes:
     taskfile: '{{.INCLUDED_REMOTE_URL}}/common.yml'
     internal: true
     vars:
-      EXTENSION: js
       FOLDER: dist
 
 tasks:
@@ -50,10 +49,10 @@ tasks:
     cmds:
       - for: { var: BINARIES_NAME }
         task: common:artifact/deliver
-        vars: { BINARY_NAME: "{{.ITEM}}" }
+        vars: { BINARY_NAME: "{{.KEY}}", EXTENSION: "{{.ITEM}}" }
 
   artifact/retrieve:
     cmds:
       - for: { var: BINARIES_NAME }
         task: common:artifact/retrieve
-        vars: { BINARY_NAME: "{{.ITEM}}" }
+        vars: { BINARY_NAME: "{{.KEY}}", EXTENSION: "{{.ITEM}}" }


### PR DESCRIPTION
Needed for Kleanads.js.
Kleanads has two files : 
- kleanads.js
- kleanads-refresh.mjs

They do not have the same extension, which was not supported by Taskfile.
This is a breaking changes so we need to update the collector / user-session at the same time
