### PR TITLE
refactor(rust): build only relevant bin

### DIFF
--- a/taskfile/rust.yml
+++ b/taskfile/rust.yml
@@ -19,7 +19,7 @@ tasks:
     requires:
       vars: [ BINARIES_NAME, RUST_WORKSPACE_DIR ]
     cmds:
-      - cargo build --target x86_64-unknown-linux-gnu --release
+      - cargo build --target x86_64-unknown-linux-gnu --release --bin {{ .BINARIES_NAME | replace " " " --bin "}}
       - for: { var: BINARIES_NAME }
         cmd: cp {{.RUST_WORKSPACE_DIR}}/target/x86_64-unknown-linux-gnu/release/{{.ITEM}} ./bootstrap && zip -r {{.ROOT_DIR}}/bin/{{.ITEM}}.zip ./bootstrap
 


### PR DESCRIPTION
Suggested by @erwanncloarec
We can use --bin to build only binaries we need