### PR TITLE
fix: bypass command test exit code 1

### DIFF
--- a/taskfile/common.yml
+++ b/taskfile/common.yml
@@ -49,9 +49,9 @@ tasks:
   _tag:
     vars:
       hasXsel:
-        sh: 'command -v xsel'
+        sh: 'command -v xsel || true'
       hasPbcopy:
-        sh: 'command -v pbcopy'
+        sh: 'command -v pbcopy || true'
     prompt: 'Did you read the next_upgrade ?'
     requires:
       vars: [STAGE, TAG]


### PR DESCRIPTION
`command -v` test if a command exists, but if it doesn't the exit code is `1`, which is causing taskfile to fail

This PR is just bypassing the exit code, and letting the result of the command (a path to the command, or empty) be enough for the existence check

Verbose output of task:
```
# if command doesn't exist
task: dynamic variable: "command -v pbcopy || true" result: ""

#if command exists
task: dynamic variable: "command -v xsel || true" result: "/usr/bin/xsel"
```