### PR TITLE
fix: include vars in infra

### DIFF
--- a/taskfile/infra.yml
+++ b/taskfile/infra.yml
@@ -1,5 +1,10 @@
 version: '3'
 
+includes:
+  vars:
+    taskfile: vars.yml
+    internal: true
+
 vars:
   DEFAULT_PLAN_PATH: /tmp/{{.PROJECT}}_plan.plan
   PLAN_PATH: '{{.PLAN_PATH | default .DEFAULT_PLAN_PATH}}'

--- a/taskfile/vars.yml
+++ b/taskfile/vars.yml
@@ -2,6 +2,6 @@ version: '3'
 
 vars:
   PROJECT:
-    sh : basename "$PWD"
+    sh : basename "{{.ROOT_DIR}}"
   GIT_REVISION:
     sh : if [[ -n ${CI} ]]; then echo ${GITHUB_SHA} | cut -c1-7; else git rev-parse --short HEAD; fi


### PR DESCRIPTION
This one is a bit tricky.
Sometimes ago Task refactor the algo to use the DAG (https://github.com/go-task/task/commit/a50580b5a1098d80202102e99894182baa68dc36).
This way we do not include the same task twice (less memory footprint). But as we are using a go routine, some files are loaded before other.
Sooo depending of the execution graph, vars can be loaded after or before the infra, resulting as {{.PROJECT}} not being available

To fix this, simply include vars in infra