### PR TITLE
chore(rust): remove ECR login as its not needed anymore

### DIFF
--- a/taskfile/rust.yml
+++ b/taskfile/rust.yml
@@ -15,7 +15,7 @@ includes:
 
 tasks:
   build:
-    deps: [ common:ecr-login, common:bin ]
+    deps: [ common:bin ]
     requires:
       vars: [ BINARIES_NAME, RUST_WORKSPACE_DIR ]
     cmds:


### PR DESCRIPTION
We do not need it anymore because we drop cross times ago