### PR TITLE
refactor(go): use gotestsum for running test

### DIFF
--- a/taskfile/go.yml
+++ b/taskfile/go.yml
@@ -27,12 +27,19 @@ tasks:
       - rm ./bootstrap
 
   test:
+    preconditions:
+      - sh: command -v gotestsum
+        msg: "gotestsum is not installed, please install it to run tests"
+    vars:
+        GOTESTSUM_FORMAT: '{{if .CI}}github-actions{{else}}testname{{end}}'
     cmds:
-      - go test -v ./...
+      - gotestsum -f '{{.GOTESTSUM_FORMAT}}' {{.CLI_ARGS}}
 
   test/coverage:
     cmds:
-      - go test ./... -count=1 -coverpkg=./... -covermode=set -coverprofile cover.out
+      - task: test
+        vars:
+          CLI_ARGS: './... -count=1 -coverpkg=./... -covermode=set -coverprofile cover.out'
       - go tool cover -func=cover.out | tail -n 1 > total-statements-coverage
 
   lint/check:


### PR DESCRIPTION
# Summary
This is a proposition to use `gotestsum` instead `go test`. gotestsum is only a UI wrapper around go test makes this human readable.

This is used by many big go project : 
- [kubernetes](https://github.com/kubernetes/kubernetes/blob/master/hack/tools/tools.go)
- [moby](https://github.com/moby/moby/blob/master/hack/test/unit) (aka Docker)
- [etcd](https://github.com/etcd-io/etcd/blob/main/tools/mod/tools.go)
- [hashicorp/vault](https://github.com/hashicorp/vault/blob/main/tools/tools.go)
- [hashicorp/consul](https://github.com/hashicorp/consul/blob/main/.github/workflows/reusable-unit.yml)
- [prometheus](https://github.com/prometheus/prometheus/blob/main/Makefile.common)
- [minikube](https://github.com/kubernetes/minikube/blob/master/hack/jenkins/common.ps1)

Exemple : 
![image](https://github.com/user-attachments/assets/dd827f1b-cd28-4ca0-86fc-d425a4181c2a)

This allow to see easily which tests failed
