### PR TITLE
feat(infra): add terraform lock task and fix apply echo message

### DIFF
--- a/taskfile/infra.yml
+++ b/taskfile/infra.yml
@@ -23,10 +23,14 @@ tasks:
     requires:
       vars: [STAGE]
     cmds:
-      - echo "planning project {{.PROJECT}} revision {{.GIT_REVISION}} on stage {{.STAGE}} ..."
+      - echo "applying project {{.PROJECT}} revision {{.GIT_REVISION}} on stage {{.STAGE}} ..."
       - terraform init -reconfigure
       - terraform workspace select -or-create {{.STAGE}}
       - terraform apply {{.PLAN_PATH}}
+
+  terraform/lock:
+    cmds:
+      - terraform providers lock -platform=linux_amd64 -platform=darwin_arm64
 
   lint/check:
     cmds:


### PR DESCRIPTION
## Summary

- Add `terraform/lock` task to generate `.terraform.lock.hcl` with cross-platform checksums (linux_amd64 + darwin_arm64)
- Fix `terraform/apply` echo message that incorrectly said "planning" instead of "applying"

## Test plan

- Verify `task terraform/lock` runs `terraform providers lock` with correct platforms in a project consuming this taskfile