### PR TITLE
feat(mongodb): add copy-prod-to-dev task excluding history collections

### DIFF
--- a/taskfile/mongodb.yml
+++ b/taskfile/mongodb.yml
@@ -65,6 +65,10 @@ tasks:
       - task: dump-prod
       - task: restore-dev
 
+  copy-prod-to-dev-no-history:
+    cmds:
+      - task: dump-prod-no-history
+      - task: restore-dev
 
   dump-prod:
     vars:
@@ -75,6 +79,18 @@ tasks:
     cmds:
       - mongodump --uri="mongodb+srv://{{.AWS_ACCESS_KEY}}:{{.AWS_SECRET_KEY}}@prod.gvqtr.mongodb.net/?authSource=%24external&authMechanism=MONGODB-AWS&retryWrites=true&w=majority&appName=prod" --db=pubstack --excludeCollection=app_audit
 
+
+  dump-prod-no-history:
+    vars:
+      AWS_ACCESS_KEY:
+        sh: aws configure get aws_access_key_id --profile pubstackmaster
+      AWS_SECRET_KEY:
+        sh: aws configure get aws_secret_access_key --profile pubstackmaster
+      HISTORY_EXCLUDES:
+        sh: |
+          mongosh "mongodb+srv://{{.AWS_ACCESS_KEY}}:{{.AWS_SECRET_KEY}}@prod.gvqtr.mongodb.net/pubstack?authSource=%24external&authMechanism=MONGODB-AWS" --quiet --eval 'db.getCollectionNames().filter(c => c.endsWith("_history")).map(c => "--excludeCollection=" + c).join(" ")'
+    cmds:
+      - mongodump --uri="mongodb+srv://{{.AWS_ACCESS_KEY}}:{{.AWS_SECRET_KEY}}@prod.gvqtr.mongodb.net/?authSource=%24external&authMechanism=MONGODB-AWS&retryWrites=true&w=majority&appName=prod" --db=pubstack --excludeCollection=app_audit {{.HISTORY_EXCLUDES}}
 
   restore-dev:
     vars:


### PR DESCRIPTION
## Summary

When copying data from prod to dev, we usually do not need histories tables, it takes times, space and so one.

- Add `copy-prod-to-dev-no-history` task that copies prod to dev while excluding all `*_history` collections

## Test plan

- Run `task mongodb:copy-prod-to-dev-no-history` and verify history collections are excluded from the dump
- Check `dump/pubstack/` directory does not contain `*_history` folders