### PR TITLE
fix(taskfile): use template base func for PROJECT var

### DIFF
--- a/taskfile/vars.yml
+++ b/taskfile/vars.yml
@@ -1,7 +1,6 @@
 version: '3'
 
 vars:
-  PROJECT:
-    sh : basename "{{.ROOT_DIR}}"
+  PROJECT: '{{base .ROOT_DIR}}'
   GIT_REVISION:
     sh : if [[ -n ${CI} ]]; then echo ${GITHUB_SHA} | cut -c1-7; else git rev-parse --short HEAD; fi


### PR DESCRIPTION
## Summary

The `PROJECT` var relied on the Unix `basename` command, which is not available on Windows when go-task runs shell snippets via the embedded `mvdan/sh` interpreter. Replace the `sh:` call with the portable Taskfile template function `{{base .ROOT_DIR}}`, removing the shell dependency entirely.

## Test plan

- macOS/Linux: run any task referencing `{{.PROJECT}}` and verify it resolves to the root directory name
- Windows: run the same task in PowerShell/cmd and confirm `basename: command not found` is gone